### PR TITLE
Working implementation (with drift) for nav2 stack.

### DIFF
--- a/waver_description/config/nav.rviz
+++ b/waver_description/config/nav.rviz
@@ -1,0 +1,327 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /LocalCostMap1/Status1
+        - /LocalCostMap1/Topic1
+      Splitter Ratio: 0.5
+    Tree Height: 739
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: LaserScan
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 0
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: false
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        accessories1_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        accessories_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        imu_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ldlidar_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        oled_screen_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        top_shell_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wheel_back_left_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wheel_back_right_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wheel_front_left_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        wheel_front_right_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 0.699999988079071
+      Binary representation: false
+      Binary threshold: 100
+      Class: rviz_default_plugins/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map
+      Update Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map_updates
+      Use Timestamp: false
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Polygon
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /local_costmap/published_footprint
+      Value: true
+    - Alpha: 0.699999988079071
+      Binary representation: false
+      Binary threshold: 100
+      Class: rviz_default_plugins/Map
+      Color Scheme: costmap
+      Draw Behind: true
+      Enabled: true
+      Name: LocalCostMap
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /local_costmap/costmap
+      Update Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /local_costmap/costmap_updates
+      Use Timestamp: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 6.511770248413086
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.8053982257843018
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.015397310256958
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1043
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000371fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f00000371000000cc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000371fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f00000371000000a900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d00650100000000000007800000026f00fffffffb0000000800540069006d006501000000000000045000000000000000000000050f0000037100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1920
+  X: 1920
+  Y: 0

--- a/waver_description/urdf/waver.gazebo.xacro
+++ b/waver_description/urdf/waver.gazebo.xacro
@@ -6,8 +6,44 @@
 
       <!-- =============== Gazebo =============== -->
       <gazebo>
-        <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-          <parameters>$(find waver_description)/config/waver_robot_sim.yaml</parameters>
+        <plugin filename="gz-sim-diff-drive-system" name="gz::sim::systems::DiffDrive">
+
+          <left_joint>wheel_front_left_joint</left_joint>
+          <left_joint>wheel_back_left_joint</left_joint>
+          <right_joint>wheel_front_right_joint</right_joint>
+          <right_joint>wheel_back_right_joint</right_joint>
+
+          <wheel_separation>0.156</wheel_separation>
+          <wheel_radius>0.026</wheel_radius> 
+
+          <!-- Control gains and limits (optional) -->
+          <max_velocity>3.0</max_velocity>                <!-- Max linear velocity in m/s -->
+          <max_linear_acceleration>1</max_linear_acceleration>
+          <min_linear_acceleration>-1</min_linear_acceleration>
+          <max_angular_acceleration>2</max_angular_acceleration>
+          <min_angular_acceleration>-2</min_angular_acceleration>
+          <max_linear_velocity>0.5</max_linear_velocity>
+          <min_linear_velocity>-0.5</min_linear_velocity>
+          <max_angular_velocity>1</max_angular_velocity>
+          <min_angular_velocity>-1</min_angular_velocity>
+
+          <topic>cmd_vel</topic> 
+
+          <odom_topic>odom</odom_topic>
+          <frame_id>odom</frame_id> 
+          <child_frame_id>base_footprint</child_frame_id> 
+          <odom_publisher_frequency>30</odom_publisher_frequency> 
+
+          <tf_topic>/tf</tf_topic> 
+
+        </plugin>
+        <plugin
+            filename="gz-sim-joint-state-publisher-system" name="gz::sim::systems::JointStatePublisher">
+            <topic>joint_states</topic> 
+            <left_joint>wheel_front_left_joint</left_joint>
+            <left_joint>wheel_back_left_joint</left_joint>
+            <right_joint>wheel_front_right_joint</right_joint>
+            <right_joint>wheel_back_right_joint</right_joint>
         </plugin>
         <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
           <render_engine>ogre2</render_engine>

--- a/waver_description/urdf/waver.xacro
+++ b/waver_description/urdf/waver.xacro
@@ -5,7 +5,6 @@
   <xacro:include filename="$(find waver_description)/urdf/util.xacro" />
   <xacro:include filename="$(find waver_description)/urdf/waver.trans.xacro" />
   <xacro:include filename="$(find waver_description)/urdf/waver.gazebo.xacro" />
-  <xacro:include filename="$(find waver_description)/ros2_control/waver_robot.ros2_control.xacro" />
   <xacro:include filename="$(find waver_description)/urdf/lidar.xacro" />
   <xacro:include filename="$(find waver_description)/urdf/imu.xacro" />
 
@@ -265,6 +264,5 @@
 
   <!-- Gazebo -->
   <xacro:waver_robot_gazebo/>
-  <xacro:waver_robot_ros2_control/>
 
 </robot>

--- a/waver_gazebo/CMakeLists.txt
+++ b/waver_gazebo/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(xacro REQUIRED)
 
 # 2) Install any resource directories (launch files, worlds, etc.) into share/
 install(
-  DIRECTORY launch world
+  DIRECTORY launch world config
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/waver_gazebo/config/ekf.yaml
+++ b/waver_gazebo/config/ekf.yaml
@@ -1,0 +1,47 @@
+### ekf config file ###
+ekf_node:
+    ros__parameters:
+# The frequency, in Hz, at which the filter will output a position estimate. Note that the filter will not begin
+# computation until it receives at least one message from one of the inputs. It will then run continuously at the
+# frequency specified here, regardless of whether it receives more measurements. Defaults to 30 if unspecified.
+        frequency: 30.0
+
+# ekf_localization_node and ukf_localization_node both use a 3D omnidirectional motion model. If this parameter is
+# set to true, no 3D information will be used in your state estimate. Use this if you are operating in a planar
+# environment and want to ignore the effect of small variations in the ground plane that might otherwise be detected
+# by, for example, an IMU. Defaults to false if unspecified.
+        two_d_mode: false
+
+# Whether to publish the acceleration state. Defaults to false if unspecified.
+        publish_acceleration: true
+
+# Whether to broadcast the transformation over the /tf topic. Defaults to true if unspecified.
+        publish_tf: true
+
+# 1. Set the map_frame, odom_frame, and base_link frames to the appropriate frame names for your system.
+#     1a. If your system does not have a map_frame, just remove it, and make sure "world_frame" is set to the value of odom_frame.
+# 2. If you are fusing continuous position data such as wheel encoder odometry, visual odometry, or IMU data, set "world_frame"
+#    to your odom_frame value. This is the default behavior for robot_localization's state estimation nodes.
+# 3. If you are fusing global absolute position data that is subject to discrete jumps (e.g., GPS or position updates from landmark
+#    observations) then:
+#     3a. Set your "world_frame" to your map_frame value
+#     3b. MAKE SURE something else is generating the odom->base_link transform. Note that this can even be another state estimation node
+#         from robot_localization! However, that instance should *not* fuse the global data.
+        map_frame: map              # Defaults to "map" if unspecified
+        odom_frame: odom            # Defaults to "odom" if unspecified
+        base_link_frame: base_link  # Defaults to "base_link" if unspecified
+        world_frame: odom           # Defaults to the value of odom_frame if unspecified
+
+        odom0: odom
+        odom0_config: [false, false, false,
+                      false, false, false,
+                      true, true, false,
+                      false, false, true,
+                      false, false, false]
+
+        imu0: imu
+        imu0_config: [false, false, false,
+                      false, false, false,
+                      false, false, false,
+                      false, false, true,
+                      false, false, false]

--- a/waver_gazebo/launch/gazebo.launch.py
+++ b/waver_gazebo/launch/gazebo.launch.py
@@ -1,23 +1,22 @@
 import os
 from pathlib import Path
+import xacro
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler, SetEnvironmentVariable, ExecuteProcess
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable, ExecuteProcess
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, Command, PathJoinSubstitution, FindExecutable
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch.event_handlers import OnProcessExit
-import xacro
 
 def generate_launch_description():
-    
+    # Paths
     waver_robot_description_path = os.path.join(
         get_package_share_directory('waver_description'))
-    
+        
     waver_robot_sim_path = os.path.join(
         get_package_share_directory('waver_gazebo'))
-    
+        
     # Set gazebo sim resource path
     gazebo_resource_path = SetEnvironmentVariable(
         name='GZ_SIM_RESOURCE_PATH',
@@ -26,13 +25,23 @@ def generate_launch_description():
             str(Path(waver_robot_description_path).parent.resolve())
             ]
         )
+    
+    rviz_config_file = os.path.join(waver_robot_description_path, 'config', 'nav.rviz')
 
+    # Path to robot description URDF
+    xacro_file = os.path.join(waver_robot_description_path,
+                              'urdf',
+                              'waver.xacro')
+    doc = xacro.process_file(xacro_file, mappings={'use_sim' : 'true'})
+    robot_desc = doc.toprettyxml(indent='  ')
+    params = {'robot_description': robot_desc}
+    
+    # Arguments
     paused_arg = DeclareLaunchArgument('paused', default_value='true')
     use_sim_time_arg = DeclareLaunchArgument('use_sim_time', default_value='true')
     gui_arg = DeclareLaunchArgument('gui', default_value='true')
     headless_arg = DeclareLaunchArgument('headless', default_value='false')
     debug_arg = DeclareLaunchArgument('debug', default_value='false')
-
     world_arg = DeclareLaunchArgument(
         'world_name',
         default_value='empty',  # ✅ Use Gazebo's built-in empty world
@@ -53,15 +62,7 @@ def generate_launch_description():
                 ]
              )
 
-    xacro_file = os.path.join(waver_robot_description_path,
-                              'urdf',
-                              'waver.xacro')
-    
-    doc = xacro.process_file(xacro_file, mappings={'use_sim' : 'true'})
-
-    robot_desc = doc.toprettyxml(indent='  ')
-
-    params = {'robot_description': robot_desc}
+    ## Initializing all the nodes ## 
 
     # (Optional) publish the robot description on /robot_description for TF, etc.
     # This is the typical approach in ROS 2: run robot_state_publisher
@@ -71,13 +72,23 @@ def generate_launch_description():
         output='screen',
         parameters=[params]
     )
-    # Sprawn the robot in Gazebo by reading from /robot_description
+
+    # EKF node
+    robot_localization_node = Node(
+        package='robot_localization',
+        executable='ekf_node',
+        name='ekf_node',
+        output='screen',
+        parameters=[os.path.join(waver_robot_sim_path, 'config/ekf.yaml'), {'use_sim_time': LaunchConfiguration('use_sim_time')}]
+    )
+
+    # Spawn the robot in Gazebo by reading from /robot_description
     spawn_robot = Node(
         package='ros_gz_sim',
         executable='create',
         output='screen',
         arguments=['-string', robot_desc,
-                   '-x', '0.0',
+                   '-x', '5.0',
                    '-y', '0.0',
                    '-z', '0.07',
                    '-R', '0.0',
@@ -87,29 +98,25 @@ def generate_launch_description():
                    '-allow_renaming', 'false'],
     )
 
-    load_joint_state_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
-    )
-
-    load_forward_velocity_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'forward_velocity_controller'],
-        output='screen'
-    )
-
     # Bridge
     bridge = Node(
         package='ros_gz_bridge',
         executable='parameter_bridge',
-        arguments=['/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan', "/imu@sensor_msgs/msg/Imu@gz.msgs.IMU", '/camera/image_raw@sensor_msgs/msg/Image@gz.msgs.Image',
-                   '/camera/camera_info@sensor_msgs/msg/CameraInfo@gz.msgs.CameraInfo'], # "/clock@rosgraph_msgs/msg/Clock@gz.msgs.Clock"
-        output='screen'
+        arguments=['/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan', 
+                   "/imu@sensor_msgs/msg/Imu@gz.msgs.IMU", 
+                   "/odom@nav_msgs/msg/Odometry@gz.msgs.Odometry",
+                   '/camera/image_raw@sensor_msgs/msg/Image@gz.msgs.Image',
+                   '/camera/camera_info@sensor_msgs/msg/CameraInfo@gz.msgs.CameraInfo', 
+                   "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock",
+                   "/joint_states@sensor_msgs/msg/JointState@gz.msgs.Model",
+                   "/tf@tf2_msgs/msg/TFMessage@gz.msgs.Pose_V",
+                   "/cmd_vel@geometry_msgs/msg/Twist@gz.msgs.Twist"],
+        output='screen',
+        parameters=[
+            {'use_sim_time': LaunchConfiguration('use_sim_time')}
+        ]
     )
-
-    rviz_config_file = os.path.join(waver_robot_description_path, 'config', 'waver_robot_config.rviz')
-
+    #  Launching RVIZ with navigation configuration
     rviz = Node(
         package="rviz2",
         executable="rviz2",
@@ -120,18 +127,6 @@ def generate_launch_description():
 
     # Build up the entire launch description
     return LaunchDescription([
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=spawn_robot,
-                on_exit=[load_joint_state_controller],
-            )
-        ),
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-               target_action=load_joint_state_controller,
-               on_exit=[load_forward_velocity_controller],
-            )
-        ),
         gazebo_resource_path,
         world_arg,
         paused_arg,
@@ -143,5 +138,6 @@ def generate_launch_description():
         robot_state_publisher,
         spawn_robot,
         bridge,
+        robot_localization_node,
         rviz,
     ])

--- a/waver_gazebo/package.xml
+++ b/waver_gazebo/package.xml
@@ -38,6 +38,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
   
 
   <!-- If you have message/service definitions in this package, you’d add them here. -->


### PR DESCRIPTION
Nav2 works now but we have a lot of drift. We figured out the problems with costmaps and added EKF, which was that our clock topic was not being published correctly by the bridge.

```
`If during startup, gazebo detects that there is another publisher on /clock, it will only create the fully qualified /world/<worldname>/clock topic.

This was introduced quite a while ago with the assumption that gazebo would be the only /clock publisher, the sole source of clock information. It was helpful if you were running multiple instances without clobbering each other.`
```